### PR TITLE
Update interp.cpp

### DIFF
--- a/src/caffe/layers/interp.cpp
+++ b/src/caffe/layers/interp.cpp
@@ -108,6 +108,6 @@ STUB_GPU(InterpLayer);
 
 
 INSTANTIATE_CLASS(InterpLayer);
-REGISTER_LAYER_CLASS(InterpLayer);
+REGISTER_LAYER_CLASS(Interp);
 
 }  // namespace caffe


### PR DESCRIPTION
fix the error that reports "boost expected primary-expression"  when compiling the caffe.